### PR TITLE
🐞 fix(#9): mock test コマンド変更

### DIFF
--- a/generate-openapi.sh
+++ b/generate-openapi.sh
@@ -85,7 +85,7 @@ echo "✅ TypeScript definitions generated at mobile-app/schema/api.d.ts"
 # Test mock command (start and immediately stop)
 echo "Testing npm run mock..."
 cd mobile-app
-timeout 5s npm run mock || true
+( npm run mock & pid=$!; sleep 5; kill -0 $pid 2>/dev/null && kill -9 $pid ) || true
 cd ..
 echo "✅ Mock server test passed"
 


### PR DESCRIPTION
This pull request updates the mock server test in the `generate-openapi.sh` script to use a more reliable method for starting and stopping the mock server process.

Testing improvements:

* Changed the mock server test command to start the server in the background, wait for 5 seconds, and then forcefully kill the process if it's still running, instead of using the `timeout` command. (`generate-openapi.sh`)