### PR TITLE
✨ feat(#36): 違反件数と違反率を表示

### DIFF
--- a/mobile-app/app/(tabs)/index.native.tsx
+++ b/mobile-app/app/(tabs)/index.native.tsx
@@ -310,7 +310,7 @@ export default function MapsScreen() {
                         longitude: item.coordinate?.[0],
                       }}
                       title={item.message}
-                      description={item.message}
+                      description={`この場所での令和6年11月の「違反件数: ${item.violation_count}件」「違反率: ${(item.violation_rate ?? 0) * 100}%」`}
                       type="VIOLATION"
                       count={item.violation_count}
                       rate={item.violation_rate}


### PR DESCRIPTION
This pull request updates the map marker descriptions on the `MapsScreen` to provide more detailed information about violations at each location.

* UI improvement:
  * Updated the `description` prop for map markers in `index.native.tsx` to display a summary including the number of violations and the violation rate for November of Reiwa 6, instead of repeating the marker title.