### PR TITLE
Fix ls-lint configuration for directory naming

### DIFF
--- a/.ls-lint.yml
+++ b/.ls-lint.yml
@@ -8,6 +8,6 @@ ls:
 ignore:
   - .git
   - .vscode
-  - api
-  - mobile-app
+  - api/*
+  - mobile-app/*
   - "!*.md"

--- a/.ls-lint.yml
+++ b/.ls-lint.yml
@@ -8,6 +8,6 @@ ls:
 ignore:
   - .git
   - .vscode
-  - api/*
-  - mobile-app/*
+  - api/**/*
+  - mobile-app/**/*
   - "!*.md"

--- a/.ls-lint.yml
+++ b/.ls-lint.yml
@@ -1,5 +1,5 @@
 ls:
-  dir: kebab-case
+  .dir: kebab-case
   .md: SCREAMING_SNAKE_CASE
   .github:
     workflows:

--- a/.ls-lint.yml
+++ b/.ls-lint.yml
@@ -1,5 +1,4 @@
 ls:
-  .dir: kebab-case
   .md: SCREAMING_SNAKE_CASE
   .github:
     workflows:
@@ -8,6 +7,6 @@ ls:
 ignore:
   - .git
   - .vscode
-  - api/**/*
-  - mobile-app/**/*
+  - api
+  - mobile-app
   - "!*.md"

--- a/mobile-app/.ls-lint.yml
+++ b/mobile-app/.ls-lint.yml
@@ -1,5 +1,5 @@
 ls:
-  dir: kebab-case
+  .dir: kebab-case
   .js: kebab-case
   .ts: kebab-case
   .tsx: kebab-case

--- a/mobile-app/.ls-lint.yml
+++ b/mobile-app/.ls-lint.yml
@@ -9,9 +9,11 @@ ls:
   .svg: kebab-case
 
 ignore:
+  - .expo
   - node_modules
   - .vscode
   - app/**/_layout.tsx
   - app/**/+not-found.tsx
   - assets/images/**/[!@]*@2x.*
   - assets/images/**/[!@]*@3x.*
+  - app/(tabs)


### PR DESCRIPTION
This pull request makes minor adjustments to the ls-lint configuration files to fix linting rules and update ignored paths. The changes ensure that directory naming conventions are correctly applied and certain files and folders are excluded from linting.

Linting configuration fixes:

* In `mobile-app/.ls-lint.yml`, corrected the key for directory linting from `dir` to `.dir` to properly enforce kebab-case on directories.
* In `.ls-lint.yml`, removed the `dir` linting rule, possibly to avoid conflicts or redundancy.

Linting ignore list updates:

* In `mobile-app/.ls-lint.yml`, added `.expo` and `app/(tabs)` to the ignore list to prevent linting in these directories.